### PR TITLE
0.4.0

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           flake8 crepr tests --max-line-length=88
           black --check crepr tests
-          ruff --no-fix crepr tests
+          ruff check --no-fix crepr tests
           yamllint .github/workflows/
       - name: Check complexity
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,6 @@ repos:
           - flake8-pep3101
           - flake8-print
           - flake8-simplify
-          - flake8-string-format
           - flake8-super
           - flake8-use-fstring
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/README.md
+++ b/README.md
@@ -2,14 +2,13 @@
 
 Create a ``__repr__`` for your python classes.
 
-A Python script that takes a file path as a command-line argument,
-imports the specified file, and creates a `__repr__` method
-for each class defined in the module.
-It uses the definition found in the  `__init__` method of the class.
+
+`crepr` is a Python script that takes a file name as a command-line argument, imports the specified module, and then adds or removes a `__repr__` method for each class defined in the module. It uses the definition found in the  `__init__` method of the class to create a useful representation of the object.
 It is pronounced /kɹeɪpr/, like 🇳🇿 crêpe.
 
 Have a look at the blog-post [Love Your Representation
 ](https://dev.to/ldrscke/love-your-representation-27mm) for the rationale of this package.
+
 
 [![Tests](https://github.com/cleder/crepr/actions/workflows/run-all-tests.yml/badge.svg?branch=main)](https://github.com/cleder/crepr/actions/workflows/run-all-tests.yml)
 [![codecov](https://codecov.io/gh/cleder/crepr/graph/badge.svg?token=EGCcrWkpay)](https://codecov.io/gh/cleder/crepr)
@@ -24,6 +23,14 @@ Have a look at the blog-post [Love Your Representation
 [![PyPI - Version](https://img.shields.io/pypi/v/crepr)](https://pypi.org/project/crepr/)
 [![Status](https://img.shields.io/pypi/status/crepr)](https://pypi.org/project/crepr/)
 
+
+## Features
+
+* Automatically generates `__repr__` methods for all classes in a Python file
+* Uses the `__init__` method's arguments to create a meaningful representation
+* Can add or remove `__repr__` methods
+* Provides options to display the diff or apply changes directly to the file
+
 ## Install
 
 ```bash
@@ -32,62 +39,24 @@ pip install crepr
 
 ## Usage
 
-```bash
-❯ crepr  --help
-Usage: crepr [OPTIONS] COMMAND [ARGS]...
-
-Options:
-  --install-completion [bash|zsh|fish|powershell|pwsh]
-                                  Install completion for the specified shell.
-  --show-completion [bash|zsh|fish|powershell|pwsh]
-                                  Show completion for the specified shell, to
-                                  copy it or customize the installation.
-  --help                          Show this message and exit.
-
-Commands:
-  add     Add __repr__ to all classes in the source code.
-  remove  Remove the __repr__ method from all classes in the source code.
-```
-
-### Add
-
-The command `crepr add ...`  adds a `__repr__` method to all classes in this file, that
-have a `__init__` method with no positional only arguments.
+To add a `__repr__` method to all classes in a file:
 
 ```bash
-❯ crepr add  --help
-Usage: crepr add [OPTIONS] FILES...
-
-  Add __repr__ to all classes in the source code.
-
-Arguments:
-  FILES...  The python source file(s)  [required]
-
-Options:
-  --kwarg-splat TEXT  The **kwarg splat  [default: ...]
-  --diff / --inline   Display the diff / Apply changes to the file(s)
-  --help              Show this message and exit.
+crepr add <file_name> [--kwarg-splat "..."] [--diff/--inline]
 ```
 
-### Remove
-
-The command `crepr remove ...` removes the `__repr__` methods from all classes that have
-an `__init__` method with no positional only arguments.
-
+To remove the `__repr__` method from all classes in a file:
 
 ```bash
-❯ crepr remove  --help
-Usage: crepr remove [OPTIONS] FILES...
-
-  Remove the __repr__ method from all classes in the source code.
-
-Arguments:
-  FILES...  The python source file(s)  [required]
-
-Options:
-  --diff / --inline  Display the diff / Apply changes to the file(s)
-  --help             Show this message and exit.
+crepr remove <file_name> [--diff/--inline]
 ```
+
+### Options
+
+* `<file_name>`: The name of the Python file to process.
+* `--kwarg-splat`: The string to use for the **kwargs splat (default: "...").
+* `--diff`: Display the diff of the changes.
+* `--inline`: Apply the changes directly to the file.
 
 ## Example
 

--- a/crepr/about.py
+++ b/crepr/about.py
@@ -1,3 +1,3 @@
 """The version number of the package."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -180,7 +180,7 @@ def create_repr_lines(
         (
             f"            f'{arg_name}={{self.{arg_name}!r}}, '"
             if arg_param.kind != inspect.Parameter.VAR_KEYWORD
-            else f"            f'**{arg_name}={kwarg_splat},'"
+            else f"            f'**{kwarg_splat},'"
         )
         for arg_name, arg_param in init_args.items()
         if arg_name != "self"
@@ -310,7 +310,7 @@ def remove_repr(file_path: pathlib.Path) -> tuple[ModuleType, dict[int, Change]]
 @app.command()
 def add(
     files: Annotated[list[pathlib.Path], file_arg],
-    kwarg_splat: Annotated[str, splat_option] = "...",
+    kwarg_splat: Annotated[str, splat_option] = "{}",
     diff: Annotated[Optional[bool], diff_inline_option] = None,  # noqa: UP007
 ) -> None:
     """Add __repr__ to all classes in the source code."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ linting = [
     "flake8-expression-complexity",
     "flake8-function-order",
     "flake8-pep3101",
-    "flake8-string-format",
     "flake8-super",
     "flake8-use-fstring",
     "ruff",

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -158,13 +158,13 @@ def test_create_repr_lines_splat_kwargs() -> None:
         "kwargs": inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD),
     }
 
-    lines = crepr.create_repr_lines(class_name, init_args, kwarg_splat=".x.x.")
+    lines = crepr.create_repr_lines(class_name, init_args, kwarg_splat="{}")
     assert lines == [
         "",
         "    def __repr__(self) -> str:",
         '        """Create a string (c)representation for SplatKwargs."""',
         "        return (f'{self.__class__.__module__}.{self.__class__.__name__}('",
-        "            f'**kwargs=.x.x.,'",
+        "            f'**{},'",
         "        ')')",
         "",
     ]

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -158,7 +158,11 @@ def test_create_repr_lines_splat_kwargs() -> None:
         "kwargs": inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD),
     }
 
-    lines = crepr.create_repr_lines(class_name, init_args, kwarg_splat="{}")
+    lines = crepr.create_repr_lines(
+        class_name,
+        init_args,
+        kwarg_splat="{}",
+    )
     assert lines == [
         "",
         "    def __repr__(self) -> str:",

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -56,10 +56,10 @@ def test_get_init_args() -> None:
     assert init_args["self"].name == "self"
     assert init_args["name"].name == "name"
     assert init_args["name"].default is inspect._empty
-    assert init_args["name"].annotation == str
+    assert init_args["name"].annotation is str
     assert init_args["age"].name == "age"
     assert init_args["age"].default is inspect._empty
-    assert init_args["age"].annotation == int
+    assert init_args["age"].annotation is int
     assert lineno == 8
     assert src[0] == "    def __init__(self: Self, name: str, *, age: int) -> None:"
 


### PR DESCRIPTION
### **User description**
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18GmU6GTkIYG2rzb5ce5GP16tttyYoGuA%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=qJ0NU6G)


___

### **PR Type**
Enhancement, Documentation, Dependencies


___

### **Description**
- Bumped the package version to 0.4.0.
- Updated the default value of `kwarg_splat` and adjusted string formatting in `crepr.py`.
- Improved test assertions and updated `kwarg_splat` value in `run_test.py`.
- Modified the `ruff` command in the GitHub Actions workflow.
- Updated versions for multiple pre-commit hooks and removed `flake8-string-format` from dependencies.
- Enhanced the README with a detailed description, features section, and simplified usage instructions.
- Removed `flake8-string-format` from linting dependencies in `pyproject.toml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>about.py</strong><dd><code>Update package version to 0.4.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crepr/about.py

- Bumped the version number from 0.3.0 to 0.4.0.



</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-6f640be106ffddffcd389f3b86ea1a7358dd7b3283dccfa8cb9e277f0b190bea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>crepr.py</strong><dd><code>Update default kwarg_splat value and string formatting</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crepr/crepr.py

<li>Modified <code>kwarg_splat</code> default value from "..." to "{}".<br> <li> Adjusted string formatting in <code>create_repr_lines</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-abcd7c4a2773c8234cdc05070d0abd10b0245a1a15f470288240c6d3a108f576">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_test.py</strong><dd><code>Improve test assertions and update kwarg_splat value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/run_test.py

<li>Updated test assertions to use <code>is</code> for type comparison.<br> <li> Adjusted <code>kwarg_splat</code> value in <code>test_create_repr_lines_splat_kwargs</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-fbc8842062fc99f82a6e71fe5954140a101062ca9fe3ac9b710195eddbcf7050">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run-all-tests.yml</strong><dd><code>Update ruff command in GitHub Actions workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/run-all-tests.yml

- Updated `ruff` command to `ruff check` in the Linting job.



</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-f715a403191ed7bfccfd1db9e835d484432652b18d6bb7da5fadfb0d6202a4bc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Update pre-commit hook versions and dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<li>Updated versions for multiple pre-commit hooks.<br> <li> Removed <code>flake8-string-format</code> from additional dependencies.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update linting dependencies in pyproject.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Removed `flake8-string-format` from linting dependencies.



</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Improve README with detailed description and usage instructions</code></dd></summary>
<hr>

README.md

<li>Enhanced the description of the <code>crepr</code> tool.<br> <li> Added a Features section.<br> <li> Simplified usage instructions.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/44/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+21/-52</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions


<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3ad2f6a25acd2fa19890760d27a5bc1ac4a07434  | 
|--------|--------|

### Summary:
Update `crepr` to version 0.4.0 with changes to `kwarg_splat` default, documentation, dependencies, and tests.

**Key points**:
- Update `crepr/about.py` to version 0.4.0.
- Modify `crepr/crepr.py` to change default `kwarg_splat` to `{}`.
- Update `README.md` to clarify usage and options for `crepr`.
- Update `.pre-commit-config.yaml` to newer versions of `black`, `ruff`, `flake8`, `mypy`, `validate-pyproject`, and `check-jsonschema`.
- Remove `flake8-string-format` from `.pre-commit-config.yaml` and `pyproject.toml`.
- Update `pyproject.toml` to reflect new dependencies and configurations.
- Modify `.github/workflows/run-all-tests.yml` to use `ruff check`.
- Update tests in `tests/run_test.py` to align with new `kwarg_splat` behavior.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Release version 0.4.0 with new features for adding and removing `__repr__` methods, enhanced documentation, updated pre-commit hooks, improved test cases, and CI workflow adjustments.

New Features:
- Introduce the ability to add or remove `__repr__` methods for all classes in a Python file using the `crepr` script.

Enhancements:
- Update the README to provide clearer instructions and examples for using the `crepr` script.
- Add a new 'Features' section in the README to highlight key functionalities of the `crepr` script.

Build:
- Update pre-commit hooks to newer versions for `black`, `ruff`, `flake8`, `mypy`, and `validate-pyproject`.

CI:
- Update the CI workflow to use the correct `ruff check` command.

Tests:
- Modify test cases to use `is` for type comparison instead of `==`.
- Update test cases to reflect changes in the `kwarg_splat` parameter.

Chores:
- Bump the version number to 0.4.0 in `crepr/about.py`.

<!-- Generated by sourcery-ai[bot]: end summary -->