### PR TITLE
Updated crepr.py for Issue #51

### DIFF
--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -353,6 +353,7 @@ def remove(
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 
+
 @app.command()
 def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
     """Count and print classes without a __repr__ method in the source code."""
@@ -387,7 +388,8 @@ def extract_classes(module, file_path: pathlib.Path):
     """Extract classes from a module."""
     try:
         return [
-            obj for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj
+            for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
@@ -396,19 +398,18 @@ def extract_classes(module, file_path: pathlib.Path):
 
 def filter_no_repr(classes):
     """Filter out classes without a __repr__ method."""
-    return [
-        obj.__name__ for obj in classes
-        if get_repr_source(obj)[1] == -1
-    ]
+    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
 
 
-def report_results(file_path: pathlib.Path, classes: list, no_repr_classes: list) -> None:
+def report_results(
+    file_path: pathlib.Path, classes: list, no_repr_classes: list,
+) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
         typer.secho(
             f"In module '{file_path}': {len(no_repr_classes)} class(es) "
             "don't have a __repr__ method:",
-            fg="yellow"
+            fg="yellow",
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
@@ -416,8 +417,9 @@ def report_results(file_path: pathlib.Path, classes: list, no_repr_classes: list
         typer.secho(
             f"All {len(classes)} class(es) in module '{file_path}' "
             "have a __repr__ method.",
-            fg="green"
+            fg="green",
         )
+
 
 if __name__ == "__main__":
     app()

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -363,9 +363,11 @@ def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
         except FileNotFoundError:
             typer.secho(f"File '{file_path}' not found.", fg="red")
         except ImportError as e:
-            typer.secho(f"Error importing module from '{file_path}': {e}", fg="red")
+            error_message = f"Error importing module from '{file_path}': {str(e)}"
+            typer.secho(error_message, fg="red")
         except Exception as e:
-            typer.secho(f"An unexpected error occurred: {e}", fg="red")
+            error_message = f"An unexpected error occurred: {str(e)}"
+            typer.secho(error_message, fg="red")
 
 
 def process_file(file_path: pathlib.Path) -> None:
@@ -376,40 +378,42 @@ def process_file(file_path: pathlib.Path) -> None:
     report_results(file_path, classes, no_repr_classes)
 
 
-def load_module(file_path: pathlib.Path):
+def load_module(file_path: pathlib.Path) -> ModuleType:
     """Load a module from a given file path."""
     try:
         return get_module(file_path)
     except ImportError as e:
-        raise ImportError(f"Failed to load module from {file_path}: {e}")
+        error_message = f"Failed to load module from {file_path}: {str(e)}"
+        raise ImportError(error_message) from None
 
 
-def extract_classes(module, file_path: pathlib.Path):
+def extract_classes(module: ModuleType, file_path: pathlib.Path) -> list[type]:
     """Extract classes from a module."""
     try:
         return [
-            obj
-            for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
-        raise AttributeError(f"Error processing classes in {file_path}: {e}")
+        error_message = f"Error processing classes in {file_path}: {str(e)}"
+        raise AttributeError(error_message) from None
 
 
-def filter_no_repr(classes):
+def filter_no_repr(classes: list[type]) -> list[str]:
     """Filter out classes without a __repr__ method."""
-    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
+    return [
+        obj.__name__ for obj in classes
+        if get_repr_source(obj)[1] == -1
+    ]
 
 
-def report_results(
-    file_path: pathlib.Path, classes: list, no_repr_classes: list,
-) -> None:
+def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str]) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
         typer.secho(
             f"In module '{file_path}': {len(no_repr_classes)} class(es) "
             "don't have a __repr__ method:",
-            fg="yellow",
+            fg="yellow"
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
@@ -417,9 +421,10 @@ def report_results(
         typer.secho(
             f"All {len(classes)} class(es) in module '{file_path}' "
             "have a __repr__ method.",
-            fg="green",
+            fg="green"
         )
-
 
 if __name__ == "__main__":
     app()
+
+

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -363,10 +363,10 @@ def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
         except FileNotFoundError:
             typer.secho(f"File '{file_path}' not found.", fg="red")
         except ImportError as e:
-            error_message = f"Error importing module from '{file_path}': {str(e)}"
+            error_message = f"Error importing module from '{file_path}': {e!s}"
             typer.secho(error_message, fg="red")
         except Exception as e:
-            error_message = f"An unexpected error occurred: {str(e)}"
+            error_message = f"An unexpected error occurred: {e!s}"
             typer.secho(error_message, fg="red")
 
 
@@ -383,7 +383,7 @@ def load_module(file_path: pathlib.Path) -> ModuleType:
     try:
         return get_module(file_path)
     except ImportError as e:
-        error_message = f"Failed to load module from {file_path}: {str(e)}"
+        error_message = f"Failed to load module from {file_path}: {e!s}"
         raise ImportError(error_message) from None
 
 
@@ -391,29 +391,29 @@ def extract_classes(module: ModuleType, file_path: pathlib.Path) -> list[type]:
     """Extract classes from a module."""
     try:
         return [
-            obj for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj
+            for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
-        error_message = f"Error processing classes in {file_path}: {str(e)}"
+        error_message = f"Error processing classes in {file_path}: {e!s}"
         raise AttributeError(error_message) from None
 
 
 def filter_no_repr(classes: list[type]) -> list[str]:
     """Filter out classes without a __repr__ method."""
-    return [
-        obj.__name__ for obj in classes
-        if get_repr_source(obj)[1] == -1
-    ]
+    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
 
 
-def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str]) -> None:
+def report_results(
+    file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str],
+) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
         typer.secho(
             f"In module '{file_path}': {len(no_repr_classes)} class(es) "
             "don't have a __repr__ method:",
-            fg="yellow"
+            fg="yellow",
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
@@ -421,10 +421,9 @@ def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes
         typer.secho(
             f"All {len(classes)} class(es) in module '{file_path}' "
             "have a __repr__ method.",
-            fg="green"
+            fg="green",
         )
+
 
 if __name__ == "__main__":
     app()
-
-

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -353,16 +353,15 @@ def remove(
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 
+
 @app.command()
-def report_missing(
-    files: Annotated[list[pathlib.Path], file_arg]
-) -> None:
+def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
     """Count and print classes without a __repr__ method in the source code."""
     for file_path in files:
         module = get_module(file_path)
         class_count = 0
         no_repr_classes = []
-        
+
         for _, obj in inspect.getmembers(module, inspect.isclass):
             if not is_class_in_module(obj, module):
                 continue
@@ -375,15 +374,16 @@ def report_missing(
             typer.secho(
                 f"In module '{file_path}': {len(no_repr_classes)} class(es) "
                 "don't have a __repr__ method:",
-                fg="yellow"
+                fg="yellow",
             )
             for lineno, class_name in no_repr_classes:
                 typer.echo(f"{file_path}: {class_name}")
         else:
             typer.secho(
                 f"All {class_count} class(es) in module '{file_path}' have a __repr__ method.",
-                fg="green"
+                fg="green",
             )
+
 
 if __name__ == "__main__":
     app()

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -363,10 +363,10 @@ def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
         except FileNotFoundError:
             typer.secho(f"File '{file_path}' not found.", fg="red")
         except ImportError as e:
-            error_message = f"Error importing module from '{file_path}': {e!s}"
+            error_message = f"Error importing module from '{file_path}': {str(e)}"
             typer.secho(error_message, fg="red")
         except Exception as e:
-            error_message = f"An unexpected error occurred: {e!s}"
+            error_message = f"An unexpected error occurred: {str(e)}"
             typer.secho(error_message, fg="red")
 
 
@@ -383,7 +383,7 @@ def load_module(file_path: pathlib.Path) -> ModuleType:
     try:
         return get_module(file_path)
     except ImportError as e:
-        error_message = f"Failed to load module from {file_path}: {e!s}"
+        error_message = f"Failed to load module from {file_path}: {str(e)}"
         raise ImportError(error_message) from None
 
 
@@ -391,39 +391,39 @@ def extract_classes(module: ModuleType, file_path: pathlib.Path) -> list[type]:
     """Extract classes from a module."""
     try:
         return [
-            obj
-            for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
-        error_message = f"Error processing classes in {file_path}: {e!s}"
+        error_message = f"Error processing classes in {file_path}: {str(e)}"
         raise AttributeError(error_message) from None
 
 
 def filter_no_repr(classes: list[type]) -> list[str]:
     """Filter out classes without a __repr__ method."""
-    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
+    return [
+        obj.__name__ for obj in classes
+        if get_repr_source(obj)[1] == -1
+    ]
 
 
-def report_results(
-    file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str],
-) -> None:
+def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str]) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
+        count_no_repr = len(no_repr_classes)
         typer.secho(
-            f"In module '{file_path}': {len(no_repr_classes)} class(es) "
-            "don't have a __repr__ method:",
-            fg="yellow",
+            f"In module '{file_path}': {count_no_repr} class(es) don't have a __repr__ method:",
+            fg="yellow"
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
     else:
+        total_classes = len(classes)
         typer.secho(
-            f"All {len(classes)} class(es) in module '{file_path}' "
-            "have a __repr__ method.",
-            fg="green",
+            f"All {total_classes} class(es) in module '{file_path}' have a __repr__ method.",
+            fg="green"
         )
-
 
 if __name__ == "__main__":
     app()
+

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -353,10 +353,9 @@ def remove(
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 
+
 @app.command()
-def report_missing(
-    files: Annotated[list[pathlib.Path], file_arg]
-) -> None:
+def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
     """Count and print classes without a __repr__ method in the source code."""
     for file_path in files:
         try:
@@ -367,13 +366,13 @@ def report_missing(
             typer.secho(
                 f"Error: Couldn't load module '{file_path}'. "
                 f"Ensure it contains an __init__.py file.",
-                fg="red"
+                fg="red",
             )
             continue  # Skip to the next file
 
         class_count = 0
         no_repr_classes = []
-        
+
         try:
             for _, obj in inspect.getmembers(module, inspect.isclass):
                 if not is_class_in_module(obj, module):
@@ -384,8 +383,8 @@ def report_missing(
                 class_count += 1
         except Exception as e:
             typer.secho(
-                f"Error: An issue occurred while inspecting '{file_path}': {str(e)}",
-                fg="red"
+                f"Error: An issue occurred while inspecting '{file_path}': {e!s}",
+                fg="red",
             )
             continue
 
@@ -393,15 +392,16 @@ def report_missing(
             typer.secho(
                 f"In module '{file_path}': {len(no_repr_classes)} class(es) "
                 "don't have a __repr__ method:",
-                fg="yellow"
+                fg="yellow",
             )
             for lineno, class_name in no_repr_classes:
                 typer.echo(f"{file_path} {lineno}: {class_name}")  # Updated format
         else:
             typer.secho(
                 f"All {class_count} class(es) in module '{file_path}' have a __repr__ method.",
-                fg="green"
+                fg="green",
             )
+
 
 if __name__ == "__main__":
     app()

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -363,10 +363,10 @@ def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
         except FileNotFoundError:
             typer.secho(f"File '{file_path}' not found.", fg="red")
         except ImportError as e:
-            error_message = f"Error importing module from '{file_path}': {e!s}"
+            error_message = f"Error importing module from '{file_path}': {str(e)}"
             typer.secho(error_message, fg="red")
         except Exception as e:
-            error_message = f"An unexpected error occurred: {e!s}"
+            error_message = f"An unexpected error occurred: {str(e)}"
             typer.secho(error_message, fg="red")
 
 
@@ -383,7 +383,7 @@ def load_module(file_path: pathlib.Path) -> ModuleType:
     try:
         return get_module(file_path)
     except ImportError as e:
-        error_message = f"Failed to load module from {file_path}: {e!s}"
+        error_message = f"Failed to load module from {file_path}: {str(e)}"
         raise ImportError(error_message) from None
 
 
@@ -391,29 +391,29 @@ def extract_classes(module: ModuleType, file_path: pathlib.Path) -> list[type]:
     """Extract classes from a module."""
     try:
         return [
-            obj
-            for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
-        error_message = f"Error processing classes in {file_path}: {e!s}"
+        error_message = f"Error processing classes in {file_path}: {str(e)}"
         raise AttributeError(error_message) from None
 
 
 def filter_no_repr(classes: list[type]) -> list[str]:
     """Filter out classes without a __repr__ method."""
-    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
+    return [
+        obj.__name__ for obj in classes
+        if get_repr_source(obj)[1] == -1
+    ]
 
 
-def report_results(
-    file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str],
-) -> None:
+def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str]) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
         typer.secho(
             f"In module '{file_path}': {len(no_repr_classes)} class(es) "
             "don't have a __repr__ method:",
-            fg="yellow",
+            fg="yellow"
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
@@ -421,9 +421,9 @@ def report_results(
         typer.secho(
             f"All {len(classes)} class(es) in module '{file_path}' "
             "have a __repr__ method.",
-            fg="green",
+            fg="green"
         )
-
 
 if __name__ == "__main__":
     app()
+

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -363,10 +363,10 @@ def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
         except FileNotFoundError:
             typer.secho(f"File '{file_path}' not found.", fg="red")
         except ImportError as e:
-            error_message = f"Error importing module from '{file_path}': {str(e)}"
+            error_message = f"Error importing module from '{file_path}': {e!s}"
             typer.secho(error_message, fg="red")
         except Exception as e:
-            error_message = f"An unexpected error occurred: {str(e)}"
+            error_message = f"An unexpected error occurred: {e!s}"
             typer.secho(error_message, fg="red")
 
 
@@ -383,7 +383,7 @@ def load_module(file_path: pathlib.Path) -> ModuleType:
     try:
         return get_module(file_path)
     except ImportError as e:
-        error_message = f"Failed to load module from {file_path}: {str(e)}"
+        error_message = f"Failed to load module from {file_path}: {e!s}"
         raise ImportError(error_message) from None
 
 
@@ -391,29 +391,29 @@ def extract_classes(module: ModuleType, file_path: pathlib.Path) -> list[type]:
     """Extract classes from a module."""
     try:
         return [
-            obj for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj
+            for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
-        error_message = f"Error processing classes in {file_path}: {str(e)}"
+        error_message = f"Error processing classes in {file_path}: {e!s}"
         raise AttributeError(error_message) from None
 
 
 def filter_no_repr(classes: list[type]) -> list[str]:
     """Filter out classes without a __repr__ method."""
-    return [
-        obj.__name__ for obj in classes
-        if get_repr_source(obj)[1] == -1
-    ]
+    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
 
 
-def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str]) -> None:
+def report_results(
+    file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str],
+) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
         typer.secho(
             f"In module '{file_path}': {len(no_repr_classes)} class(es) "
             "don't have a __repr__ method:",
-            fg="yellow"
+            fg="yellow",
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
@@ -421,9 +421,9 @@ def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes
         typer.secho(
             f"All {len(classes)} class(es) in module '{file_path}' "
             "have a __repr__ method.",
-            fg="green"
+            fg="green",
         )
+
 
 if __name__ == "__main__":
     app()
-

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -363,10 +363,10 @@ def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
         except FileNotFoundError:
             typer.secho(f"File '{file_path}' not found.", fg="red")
         except ImportError as e:
-            error_message = f"Error importing module from '{file_path}': {str(e)}"
+            error_message = f"Error importing module from '{file_path}': {e!s}"
             typer.secho(error_message, fg="red")
         except Exception as e:
-            error_message = f"An unexpected error occurred: {str(e)}"
+            error_message = f"An unexpected error occurred: {e!s}"
             typer.secho(error_message, fg="red")
 
 
@@ -383,7 +383,7 @@ def load_module(file_path: pathlib.Path) -> ModuleType:
     try:
         return get_module(file_path)
     except ImportError as e:
-        error_message = f"Failed to load module from {file_path}: {str(e)}"
+        error_message = f"Failed to load module from {file_path}: {e!s}"
         raise ImportError(error_message) from None
 
 
@@ -391,29 +391,29 @@ def extract_classes(module: ModuleType, file_path: pathlib.Path) -> list[type]:
     """Extract classes from a module."""
     try:
         return [
-            obj for _, obj in inspect.getmembers(module, inspect.isclass)
+            obj
+            for _, obj in inspect.getmembers(module, inspect.isclass)
             if is_class_in_module(obj, module)
         ]
     except AttributeError as e:
-        error_message = f"Error processing classes in {file_path}: {str(e)}"
+        error_message = f"Error processing classes in {file_path}: {e!s}"
         raise AttributeError(error_message) from None
 
 
 def filter_no_repr(classes: list[type]) -> list[str]:
     """Filter out classes without a __repr__ method."""
-    return [
-        obj.__name__ for obj in classes
-        if get_repr_source(obj)[1] == -1
-    ]
+    return [obj.__name__ for obj in classes if get_repr_source(obj)[1] == -1]
 
 
-def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str]) -> None:
+def report_results(
+    file_path: pathlib.Path, classes: list[type], no_repr_classes: list[str],
+) -> None:
     """Report the results of classes without a __repr__ method."""
     if no_repr_classes:
         count_no_repr = len(no_repr_classes)
         typer.secho(
             f"In module '{file_path}': {count_no_repr} class(es) don't have a __repr__ method:",
-            fg="yellow"
+            fg="yellow",
         )
         for class_name in no_repr_classes:
             typer.echo(f"{file_path}: {class_name}")
@@ -421,9 +421,9 @@ def report_results(file_path: pathlib.Path, classes: list[type], no_repr_classes
         total_classes = len(classes)
         typer.secho(
             f"All {total_classes} class(es) in module '{file_path}' have a __repr__ method.",
-            fg="green"
+            fg="green",
         )
+
 
 if __name__ == "__main__":
     app()
-

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -353,37 +353,55 @@ def remove(
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 
-
 @app.command()
-def report_missing(files: Annotated[list[pathlib.Path], file_arg]) -> None:
+def report_missing(
+    files: Annotated[list[pathlib.Path], file_arg]
+) -> None:
     """Count and print classes without a __repr__ method in the source code."""
     for file_path in files:
-        module = get_module(file_path)
+        try:
+            # Attempt to load the module
+            module = get_module(file_path)
+        except ModuleNotFoundError:
+            # Handle the case where __init__.py is missing or the module cannot be loaded
+            typer.secho(
+                f"Error: Couldn't load module '{file_path}'. "
+                f"Ensure it contains an __init__.py file.",
+                fg="red"
+            )
+            continue  # Skip to the next file
+
         class_count = 0
         no_repr_classes = []
-
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if not is_class_in_module(obj, module):
-                continue
-            _, lineno = get_repr_source(obj)
-            if lineno == -1:
-                no_repr_classes.append((lineno, obj.__name__))
-            class_count += 1
+        
+        try:
+            for _, obj in inspect.getmembers(module, inspect.isclass):
+                if not is_class_in_module(obj, module):
+                    continue
+                _, lineno = get_repr_source(obj)
+                if lineno == -1:
+                    no_repr_classes.append((lineno, obj.__name__))
+                class_count += 1
+        except Exception as e:
+            typer.secho(
+                f"Error: An issue occurred while inspecting '{file_path}': {str(e)}",
+                fg="red"
+            )
+            continue
 
         if no_repr_classes:
             typer.secho(
                 f"In module '{file_path}': {len(no_repr_classes)} class(es) "
                 "don't have a __repr__ method:",
-                fg="yellow",
+                fg="yellow"
             )
             for lineno, class_name in no_repr_classes:
-                typer.echo(f"{file_path}: {class_name}")
+                typer.echo(f"{file_path} {lineno}: {class_name}")  # Updated format
         else:
             typer.secho(
                 f"All {class_count} class(es) in module '{file_path}' have a __repr__ method.",
-                fg="green",
+                fg="green"
             )
-
 
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
### **User description**
### Added the `report_missing` method

The `report_missing` method is a Typer command that inspects the classes in a given Python file to identify and count those without a `__repr__` method as required in https://github.com/cleder/crepr/issues/51

1. **Input Handling**:
   - The function accepts a list of file paths (`files`) as an argument, which corresponds to Python files that need to be analyzed.

2.**Tracking Classes without `__repr__`**:
   - For each class, it checks if the class has a `__repr__` method by calling `get_repr_source`.
   - If the class doesn't have a `__repr__` method, its name is added to the `no_repr_classes` list, and the class count is incremented.

3. **Reporting**:
   - After analyzing all the classes in a file, the function prints a summary showing how many classes in that file are missing a `__repr__` method.
   - If any classes lack a `__repr__`, their names are printed.
   
   ### Usage for `report-missing`
   ```python
   crepr report-missing <your-file-name>
   ```


___

### **PR Type**
enhancement


___

### **Description**
- Introduced a new Typer command `report_missing` to the `crepr` application.
- The command analyzes specified Python files to count and list classes that do not implement a `__repr__` method.
- Provides a summary output indicating the number of classes missing the `__repr__` method or confirms all classes have it.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crepr.py</strong><dd><code>Add `report_missing` command to check for missing `__repr__` methods</code></dd></summary>
<hr>

crepr/crepr.py

<li>Added a new <code>report_missing</code> command to the application.<br> <li> The command inspects classes in specified Python files to identify <br>those without a <code>__repr__</code> method.<br> <li> Outputs a summary of classes missing the <code>__repr__</code> method or confirms <br>all classes have it.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/52/files#diff-abcd7c4a2773c8234cdc05070d0abd10b0245a1a15f470288240c6d3a108f576">+31/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new Typer command `report_missing` to the crepr.py script, which analyzes specified Python files to report classes missing a `__repr__` method.

New Features:
- Introduce the `report_missing` Typer command to identify and count classes in a Python file that lack a `__repr__` method.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command function, `report_missing`, to analyze specified files for classes lacking a `__repr__` method and report the findings, including error handling and user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->