### PR TITLE
feat: sparse output of the changes

### DIFF
--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -366,6 +366,8 @@ def add(
         if not changes:
             continue
 
+        src = insert_changes(module, changes) if diff is not None else None
+
         if diff is None:
             for change in changes.values():
                 typer.echo(f"__repr__ generated for class: {change['class_name']}")
@@ -373,11 +375,9 @@ def add(
                 typer.echo("")
         elif diff:
             before = inspect.getsource(module).splitlines()
-            src = insert_changes(module, changes)
             _diff = difflib.unified_diff(before, src, lineterm="")
             typer.echo("\n".join(_diff))
         else:
-            src = insert_changes(module, changes)
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 
@@ -393,6 +393,8 @@ def remove(
         if not changes:
             continue
 
+        src = remove_changes(module, changes) if diff is not None else None
+
         if diff is None:
             for change in changes.values():
                 typer.echo(f"__repr__ removed from class: {change['class_name']}")
@@ -400,7 +402,6 @@ def remove(
                 typer.echo("")
         elif diff:
             before = inspect.getsource(module).splitlines()
-            src = remove_changes(module, changes)
             _diff = difflib.unified_diff(before, src, lineterm="")
             typer.echo("\n".join(_diff))
         else:

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -366,8 +366,8 @@ def apply_changes(
     module: ModuleType,
     changes: dict[int, Change],
     file_path: pathlib.Path,
-    diff: bool,  # noqa: FBT001 FBT002
-    change_func: Callable[[ModuleType, dict[int, Change]], list[str]]
+    diff: bool,  # noqa: FBT001
+    change_func: Callable[[ModuleType, dict[int, Change]], list[str]],
 ) -> None:
     """Apply changes to the module and handle diff or file writing."""
     src = change_func(module, changes)
@@ -396,7 +396,9 @@ def add(
         if diff is None:
             print_changes(changes, "generated")
         else:
-            apply_changes(module, changes, file_path, diff, insert_changes)
+            apply_changes(
+                module, changes, file_path, diff=diff, change_func=insert_changes
+            )
 
 
 @app.command()
@@ -413,7 +415,9 @@ def remove(
         if diff is None:
             print_changes(changes, "removed")
         else:
-            apply_changes(module, changes, file_path, diff, remove_changes)
+            apply_changes(
+                module, changes, file_path, diff=diff, change_func=remove_changes
+            )
 
 
 @app.command()

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -365,15 +365,19 @@ def add(
         changes = create_repr(module, kwarg_splat, ignore_existing)
         if not changes:
             continue
-        src = insert_changes(module, changes)
+
         if diff is None:
-            typer.echo("\n".join(src))
+            for change in changes.values():
+                typer.echo(f"__repr__ generated for class: {change['class_name']}")
+                typer.echo("\n".join(change["lines"]))
+                typer.echo("")
         elif diff:
             before = inspect.getsource(module).splitlines()
+            src = insert_changes(module, changes)
             _diff = difflib.unified_diff(before, src, lineterm="")
             typer.echo("\n".join(_diff))
-            continue
         else:
+            src = insert_changes(module, changes)
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 
@@ -388,15 +392,19 @@ def remove(
         changes = remove_repr(module)
         if not changes:
             continue
-        src = remove_changes(module, changes)
+
         if diff is None:
-            typer.echo("\n".join(src))
+            for change in changes.values():
+                typer.echo(f"__repr__ removed from class: {change['class_name']}")
+                typer.echo("\n".join(change["lines"]))
+                typer.echo("")
         elif diff:
             before = inspect.getsource(module).splitlines()
+            src = remove_changes(module, changes)
             _diff = difflib.unified_diff(before, src, lineterm="")
             typer.echo("\n".join(_diff))
-            continue
         else:
+            src = remove_changes(module, changes)
             with file_path.open(mode="w", encoding="UTF-8") as f:
                 f.write("\n".join(src))
 

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -12,6 +12,7 @@ import importlib.machinery
 import inspect
 import pathlib
 import uuid
+from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Iterator
 from types import MappingProxyType
@@ -20,7 +21,6 @@ from typing import Annotated
 from typing import Optional
 from typing import Self
 from typing import TypedDict
-from typing import Callable
 
 import typer
 
@@ -366,8 +366,8 @@ def apply_changes(
     module: ModuleType,
     changes: dict[int, Change],
     file_path: pathlib.Path,
-    diff: bool,
-    change_func: Callable,
+    diff: bool,  # noqa: FBT001 FBT002
+    change_func: Callable[[ModuleType, dict[int, Change]], list[str]]
 ) -> None:
     """Apply changes to the module and handle diff or file writing."""
     src = change_func(module, changes)

--- a/crepr/crepr.py
+++ b/crepr/crepr.py
@@ -397,7 +397,11 @@ def add(
             print_changes(changes, "generated")
         else:
             apply_changes(
-                module, changes, file_path, diff=diff, change_func=insert_changes
+                module,
+                changes,
+                file_path,
+                diff=diff,
+                change_func=insert_changes,
             )
 
 
@@ -416,7 +420,11 @@ def remove(
             print_changes(changes, "removed")
         else:
             apply_changes(
-                module, changes, file_path, diff=diff, change_func=remove_changes
+                module,
+                changes,
+                file_path,
+                diff=diff,
+                change_func=remove_changes,
             )
 
 

--- a/tests/run_test.py
+++ b/tests/run_test.py
@@ -276,7 +276,7 @@ def test_show_remove() -> None:
     result = runner.invoke(crepr.app, ["remove", "tests/remove/kw_only_test.py"])
 
     assert result.exit_code == 0
-    assert "__repr__ removed from class: KwOnly" in result.stdout
+    assert "__repr__ removed for class: KwOnly" in result.stdout
     assert len(result.stdout.splitlines()) == 10
 
 
@@ -390,7 +390,7 @@ def test_remove_show_only_changes() -> None:
     result = runner.invoke(crepr.app, ["remove", "tests/remove/kw_only_test.py"])
 
     assert result.exit_code == 0
-    assert "__repr__ removed from class: KwOnly" in result.stdout
+    assert "__repr__ removed for class: KwOnly" in result.stdout
     assert "def __repr__(self: Self) -> str:" in result.stdout
     assert '"""Create a string (c)representation for KwOnly."""' in result.stdout
     assert "return (" in result.stdout


### PR DESCRIPTION
### **User description**
When the `add` or `remove` commands are run without the `--diff` or `--inline` switch, the script will now display the proposed changes on the screen, including the name of the class and the code of the `__repr__` method that is being added or removed.

Fixes #57


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the `add` and `remove` commands to display the class name and proposed changes when neither `--diff` nor `--inline` options are used.
- Updated the `add` and `remove` functions to improve the clarity of the output by showing specific changes being applied to classes.
- Added new tests to verify the enhanced output format and updated existing tests to align with the new output expectations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>crepr.py</strong><dd><code>Enhance output for add and remove commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crepr/crepr.py

<li>Modified <code>add</code> and <code>remove</code> functions to display class name and changes.<br> <li> Enhanced output when <code>--diff</code> or <code>--inline</code> is not used.<br> <li> Improved clarity of changes being applied to classes.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/64/files#diff-abcd7c4a2773c8234cdc05070d0abd10b0245a1a15f470288240c6d3a108f576">+14/-6</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>run_test.py</strong><dd><code>Update and add tests for enhanced output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/run_test.py

<li>Added tests for new output format in <code>add</code> and <code>remove</code> commands.<br> <li> Updated existing tests to match new output expectations.<br> <li> Verified only proposed changes are shown without <code>--diff</code> or <code>--inline</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/cleder/crepr/pull/64/files#diff-fbc8842062fc99f82a6e71fe5954140a101062ca9fe3ac9b710195eddbcf7050">+36/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information

## Summary by Sourcery

Implement sparse output for `add` and `remove` commands to display proposed changes without `--diff` or `--inline` switches, and update tests to cover this new behavior.

New Features:
- Display proposed changes for `add` and `remove` commands when run without `--diff` or `--inline` switches, showing the class name and the code of the `__repr__` method being added or removed.

Tests:
- Add tests to verify that only proposed changes are shown when `add` and `remove` commands are executed without `--diff` or `--inline` switches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced output clarity for `add` and `remove` commands, providing explicit messages about generated and removed `__repr__` methods.
	- Streamlined handling of source code changes for more consistent feedback.

- **Bug Fixes**
	- Updated tests to ensure accurate output messages for `add` and `remove` commands, reflecting only relevant changes.

- **Tests**
	- Added new tests to verify that output correctly shows changes without requiring additional flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->